### PR TITLE
Restore "profile " prefix

### DIFF
--- a/wrapp/aws/mfa.py
+++ b/wrapp/aws/mfa.py
@@ -44,7 +44,7 @@ def get_credentials(args: argparse.Namespace) -> dict:
         config = configparser.ConfigParser()
         config.read(expanduser("~/.aws/config"))
         try:
-            profile = config[args.profile]
+            profile = config["profile " + args.profile]
         except KeyError:
             print("# Profile '%s' not found!" % args.profile, file=sys.stderr)
             sys.exit(-1)


### PR DESCRIPTION
This reverts this commit https://github.com/wrapp/aws-mfa-login/commit/6f2ad1bf596864a4e7558846b4b818ae2e87f5fb#diff-7ba15dc54b8e9c957de429068be85fbbf225e9202c1fc7fae44a9876038396dd

Gets `aws-mfa-login` working again